### PR TITLE
Removed bug from README-It doesn't work in the previous case. The sta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ The steps in the `start_tracking.sh` script are explained in details below:
 * Make the camera face downward (pitch rotation of -90 degrees)
     ```sh
     rostopic pub --once /mavros/mount_control/command mavros_msgs/MountControl "header:
-    seq: 0
-    stamp: {secs: 0, nsecs: 0}
-    frame_id: ''
+      seq: 0
+      stamp: {secs: 0, nsecs: 0}
+      frame_id: ''
     mode: 2
     pitch: -90.0
     roll: 0.0


### PR DESCRIPTION
…rt_tracking.sh file is different.  
I tried this out, it wasn't working, it took me a time(and cloning the repo) to understand the mistake.   
I didn't try the version that I pushed here but it is now the same with the sh file.  
The version I tried and working is:  
```sh
rostopic pub --once /uav1/mavros/mount_control/command mavros_msgs/MControl '{header: { seq: 0, stamp: {secs: 0, nsecs: 0}, frame_id: ""}, mode: 2, pitch: -45.0, roll: 0.0, yaw: 0.0, altitude: 0.0, latitude: 0.0, longitude: 0.0}'
```